### PR TITLE
Fix quoting in bash script

### DIFF
--- a/nix/bootstrap.sh
+++ b/nix/bootstrap.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -eu
 
 # Set up soft links from files to their destination (in home directory)
 
@@ -8,42 +9,42 @@
 # And HP doesn't define $PWD in a sudo environment, so we define our own
 case $0 in
     /*|~*)
-        SCRIPT_INDIRECT="`dirname $0`"
+        SCRIPT_INDIRECT="$(dirname "$0")"
         ;;
     *)
         PWD="`pwd`"
-        SCRIPT_INDIRECT="`dirname $PWD/$0`"
+        SCRIPT_INDIRECT="$(dirname "$PWD/$0")"
         ;;
 esac
 
-BASEDIR="`(cd \"$SCRIPT_INDIRECT\"; pwd -P)`"
+BASEDIR="$(cd "$SCRIPT_INDIRECT" ; pwd -P)"
 
-for i in $BASEDIR/*; do
-    [ ! -d $i ] && continue
+for i in "$BASEDIR"/*; do
+    [ ! -d "$i" ] && continue
 
-    for j in $i/*; do
-        FILEDIR=`dirname $j`
-        FILE=`basename $j`
-        BASEFILE=$HOME/.$FILE
+    for j in "$i"/*; do
+        FILEDIR="$(dirname "$j")"
+        FILE="$(basename "$j")"
+        BASEFILE="$HOME/.$FILE"
  
-        if [ -f $BASEFILE -o -h $BASEFILE ]; then
+        if [ -f "$BASEFILE" -o -h "$BASEFILE" ]; then
             echo "Replacing file: $BASEFILE"
-            rm $BASEFILE
+            rm "$BASEFILE"
         else
             echo "Creating link: $BASEFILE"
         fi
 
-        ln -s $j $BASEFILE
+        ln -s "$j" "$BASEFILE"
     done
 done
 
 # Make a pass deleting stale links, if any
 for i in ~/.*; do
-    [ ! -h $i ] && continue
+    [ ! -h "$i" ] && continue
 
     # We have a link: Is it stale? If so, delete it ...
-    if [ ! -f $i ]; then
+    if [ ! -f "$i" ]; then
         echo "Deleting stale link: $i"
-        rm $i
+        rm "$i"
     fi
 done


### PR DESCRIPTION
In this diff:

* Use `set -eu` for a slightly saner bash execution environment
* Double quote all the things, to handle paths including whitespace
* Use `$(...)` in place of ` ``...`` `